### PR TITLE
Fix unflatten algorithm and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Below are the main modules available in `dbl-utils`:
 
 For a detailed description of each module and function, visit the [full documentation](https://joneldiablo.github.io/dbl-utils/modules.html) automatically generated with Typedoc. The documentation includes usage examples and in-depth explanations of each function.
 
+## TODO
+
+- Move number compact formatting to the i18n module.
+
 ## License
 
 This project is under the ISC license. See the `LICENSE` file for more details.

--- a/src/format-value.ts
+++ b/src/format-value.ts
@@ -38,7 +38,7 @@ export default function formatValue(value: any, conf: FormatConfig): any {
   switch (conf.format) {
     case 'number-compact':
     case 'numbercompact': {
-      //TODO: mover a i18n
+      // TODO: move to i18n
       numeral.locale(getLang());
       return numeral(value).format(conf.formatConf as string || formatNumberCompact(conf.context));
     }

--- a/src/purge-css-cli.ts
+++ b/src/purge-css-cli.ts
@@ -1,6 +1,6 @@
 #! bin/ts-node
 import * as path from "path";
-import purgeCss from "./purge-css"; // Importa la función desde otro archivo
+import purgeCss from "./purge-css"; // Import the function from another file
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 


### PR DESCRIPTION
## Summary
- fix unflatten so arrays are rebuilt correctly
- translate remaining Spanish comments
- document TODO item
- add examples in typedoc comments

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688131786abc8326913e38de2abcf513

## Summary by Sourcery

Fix unflatten algorithm to rebuild arrays correctly, enrich documentation with examples and TODO, and translate Spanish comments to English.

Bug Fixes:
- Correct the unflatten function to properly reconstruct nested arrays.

Enhancements:
- Add JSDoc usage examples for flatten and unflatten functions.
- Translate Spanish comments and unify TODO comment formatting in code.

Documentation:
- Document the TODO in README to move number-compact formatting to the i18n module.