### PR TITLE
Add docs for unflatten arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Below are the main modules available in `dbl-utils`:
 
 For a detailed description of each module and function, visit the [full documentation](https://joneldiablo.github.io/dbl-utils/modules.html) automatically generated with Typedoc. The documentation includes usage examples and in-depth explanations of each function.
 
+## Recent Changes
+
+- Fixed handling of numeric keys in `unflatten` so arrays are reconstructed correctly.
+
 ## TODO
 
 - Move number compact formatting to the i18n module.

--- a/src/flat.ts
+++ b/src/flat.ts
@@ -91,9 +91,19 @@ export function flatten(
 
 /**
  * Reconstructs a nested object from a flattened one using a delimiter.
- * @param object The flattened object.
- * @param delimiter The string delimiter used to split keys.
+ * Numeric keys are automatically treated as array indices so arrays
+ * are recreated correctly.
+ *
+ * @param object - The flattened object.
+ * @param delimiter - The string delimiter used to split keys.
  * @returns The nested (unflattened) object.
+ *
+ * @example
+ * ```ts
+ * const obj = { 'a.0': 1, 'a.1': 2 };
+ * unflatten(obj);
+ * // => { a: [1, 2] }
+ * ```
  */
 export function unflatten(
   object: Record<string, any>,

--- a/src/object-mutation.ts
+++ b/src/object-mutation.ts
@@ -103,6 +103,12 @@ export function deepMerge(target: any, ...sources: any[]): any {
   return mergedObject;
 }
 
+/**
+ * Configure deep merge behavior. Useful for setting a custom
+ * fixer function before calling {@link deepMerge}.
+ *
+ * @param config - Configuration options.
+ */
 deepMerge.setConfig = (config: ConfigOptions) => {
   useConfig = config;
 };


### PR DESCRIPTION
## Summary
- document array handling fix in `unflatten`
- add example in Typedoc comment
- document `deepMerge.setConfig`
- note recent changes in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68813f9266cc8326b16ba4e054b0137c

## Summary by Sourcery

Document the array reconstruction fix in unflatten with a usage example, add JSDoc comments for deepMerge.setConfig, and update README with recent changes.

Documentation:
- Add JSDoc documentation for deepMerge.setConfig to explain its configuration behavior.
- Enhance unflatten documentation to describe numeric key handling for arrays and include a Typedoc usage example.
- Update README with a 'Recent Changes' section noting the unflatten numeric key fix.