### PR TITLE
Add missing tests and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,20 @@ Below are the main modules available in `dbl-utils`:
 
 For a detailed description of each module and function, visit the [full documentation](https://joneldiablo.github.io/dbl-utils/modules.html) automatically generated with Typedoc. The documentation includes usage examples and in-depth explanations of each function.
 
+## Testing
+
+Run the test suite with:
+
+```bash
+npm test
+```
+
+This project uses Jest with ts-jest. New tests cover the `i18n` and `object-mutation` modules.
+
 ## Recent Changes
 
 - Fixed handling of numeric keys in `unflatten` so arrays are reconstructed correctly.
+- Added unit tests for the `i18n` and `object-mutation` modules.
 
 ## TODO
 

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -1,0 +1,18 @@
+import t, { addDictionary, setLang, addFormatDate, formatDate } from '../src/i18n';
+
+describe('i18n utilities', () => {
+  beforeEach(() => {
+    addDictionary({ default: { hello: 'Hello' }, es: { hello: 'Hola' } });
+  });
+
+  test('translates text based on current language', () => {
+    setLang('es');
+    expect(t('hello')).toBe('Hola');
+  });
+
+  test('formatDate uses locale specific format', () => {
+    addFormatDate({ es: 'DD/MM/YYYY' });
+    setLang('es');
+    expect(formatDate()).toBe('DD/MM/YYYY');
+  });
+});

--- a/__tests__/object-mutation.test.ts
+++ b/__tests__/object-mutation.test.ts
@@ -1,0 +1,24 @@
+import { deepMerge, mergeWithMutation, transformJson } from '../src/object-mutation';
+
+describe('object-mutation utilities', () => {
+  test('deepMerge merges nested objects', () => {
+    const objA = { foo: { bar: 1 } };
+    const objB = { foo: { baz: 2 } };
+    const result = deepMerge({}, objA, objB);
+    expect(result).toEqual({ foo: { bar: 1, baz: 2 } });
+  });
+
+  test('mergeWithMutation applies mutation recursively', async () => {
+    const data = { a: { b: 1 } } as any;
+    await mergeWithMutation(data, {
+      mutation: () => ({ c: 2 }),
+    });
+    expect(data).toEqual({ a: { b: 1, c: 2 } });
+  });
+
+  test('transformJson returns copy and undefined flat object by default', () => {
+    const [copy, flat] = transformJson({ a: { b: 1 } });
+    expect(copy).toEqual({ a: { b: 1 } });
+    expect(flat).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add test coverage for i18n and object-mutation modules
- document how to run tests
- log new changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68825268bfb88326af0c767514da0efc