### PR TITLE
Increase test coverage to 80%

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ This project uses Jest with ts-jest. New tests cover the `i18n` and `object-muta
 
 - Fixed handling of numeric keys in `unflatten` so arrays are reconstructed correctly.
 - Added unit tests for the `i18n` and `object-mutation` modules.
+- Expanded coverage with additional tests for `utils`, `format-value`, and `i18n`.
 
 ## TODO
 

--- a/__tests__/format-value.test.ts
+++ b/__tests__/format-value.test.ts
@@ -1,4 +1,5 @@
 import formatValue from '../src/format-value';
+import numeral from 'numeral';
 import { addDictionary, setLang } from '../src/i18n';
 
 describe('formatValue', () => {
@@ -15,6 +16,36 @@ describe('formatValue', () => {
   it('formats dictionary values', () => {
     const result = formatValue('hello', { format: 'dictionary' });
     expect(result).toBe('Hello');
+  });
+
+  it('formats numbers in compact form', () => {
+    const localeSpy = jest.spyOn(numeral, 'locale');
+    const result = formatValue(1500, { format: 'number-compact' });
+    expect(localeSpy).toHaveBeenCalledWith('en');
+    expect(result).toBe('1.50k');
+  });
+
+  it('formats currency using provided options', () => {
+    const result = formatValue(1000, {
+      format: 'currency',
+      formatConf: { currency: 'USD', style: 'currency', minimumFractionDigits: 2 }
+    });
+    expect(result).toBe('$1,000.00');
+  });
+
+  it('throws when currency format configuration is invalid', () => {
+    expect(() =>
+      formatValue(10, { format: 'currency', formatConf: 'bad' as any })
+    ).toThrow('currency format must have formatConf as an Intl.NumberFormatOptions');
+  });
+
+  it('formats dates and times', () => {
+    const date = new Date('2024-01-02T03:04:05Z');
+    expect(formatValue(date, { format: 'date', formatConf: 'YYYY-MM-DD' })).toBe('2024-01-02');
+    expect(formatValue(date, { format: 'time', formatConf: 'HH:mm' })).toBe('03:04');
+    expect(
+      formatValue(date, { format: 'date-time', formatConf: 'YYYY-MM-DD HH:mm' })
+    ).toBe('2024-01-02 03:04');
   });
 });
 

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -1,4 +1,15 @@
-import t, { addDictionary, setLang, addFormatDate, formatDate } from '../src/i18n';
+import t, {
+  addDictionary,
+  setLang,
+  addFormatDate,
+  formatDate,
+  trackingTexts,
+  getTexts,
+  addFormatNumberCompact,
+  formatNumberCompact,
+  addTasks,
+  removeTask
+} from '../src/i18n';
 
 describe('i18n utilities', () => {
   beforeEach(() => {
@@ -14,5 +25,27 @@ describe('i18n utilities', () => {
     addFormatDate({ es: 'DD/MM/YYYY' });
     setLang('es');
     expect(formatDate()).toBe('DD/MM/YYYY');
+  });
+
+  test('trackingTexts collects keys', () => {
+    trackingTexts(true);
+    t('hello');
+    trackingTexts(false);
+    expect(getTexts()).toContain('hello');
+  });
+
+  test('formatNumberCompact uses language specific config', () => {
+    addFormatNumberCompact({ es: '0a' });
+    setLang('es');
+    expect(formatNumberCompact()).toBe('0a');
+  });
+
+  test('addTasks executes on language change and can be removed', () => {
+    const spy = jest.fn();
+    addTasks({ test: spy });
+    setLang('fr');
+    expect(spy).toHaveBeenCalledWith('fr');
+    expect(removeTask('test')).toBe(true);
+    expect(removeTask('test')).toBe(false);
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,17 @@
-import { normalize, slugify, timeChunks } from '../src/utils';
+import {
+  normalize,
+  slugify,
+  timeChunks,
+  sliceIntoChunks,
+  splitAndFlat,
+  evaluateColorSimilarity,
+  randomS4,
+  randomString,
+  hash,
+  LCG,
+  delay,
+  generateRandomColors
+} from '../src/utils';
 
 describe('utils', () => {
   test('normalize and slugify strings', () => {
@@ -12,5 +25,76 @@ describe('utils', () => {
     expect(result.length).toBe(2);
     expect(result[0]).toHaveProperty('from');
     expect(result[0]).toHaveProperty('to');
+  });
+
+  test('timeChunks validates input', () => {
+    expect(() => timeChunks({ from: 'x', to: 'y', step: 0 })).toThrow();
+  });
+
+  test('sliceIntoChunks splits arrays', () => {
+    const chunks = sliceIntoChunks([1, 2, 3, 4, 5], 2);
+    expect(chunks).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  test('splitAndFlat processes string arrays', () => {
+    const result = splitAndFlat(['a b', 'b', false], ' ');
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  test('timeChunks respects day boundary', () => {
+    const chunks = timeChunks({
+      from: '2020-01-01T20:00:00',
+      to: '2020-01-02T04:00:00',
+      step: 8,
+      boundary: 'day'
+    });
+    expect(chunks[0].to).toContain('2020-01-01');
+  });
+
+  test('evaluateColorSimilarity detects identical colors', () => {
+    expect(evaluateColorSimilarity(['#fff', '#fff'])).toBe(1);
+    expect(evaluateColorSimilarity(['#000', '#fff'])).toBeLessThan(1);
+  });
+
+  test('randomS4 generates 4 hex chars', () => {
+    expect(randomS4()).toMatch(/^[a-f0-9]{4}$/);
+  });
+
+  test('generateRandomColors returns correct formats', () => {
+    const hex = generateRandomColors(2); // default hex
+    expect(hex).toHaveLength(2);
+    expect(hex[0]).toMatch(/^#/);
+
+    const rgb = generateRandomColors(1, { format: 'rgb' })[0] as number[];
+    expect(rgb).toHaveLength(3);
+
+    const nrgb = generateRandomColors(1, { format: 'nrgb' })[0] as number[];
+    expect(nrgb[0]).toBeGreaterThanOrEqual(0);
+    expect(nrgb[0]).toBeLessThanOrEqual(1);
+  });
+
+  test('randomString respects length and characters', () => {
+    expect(randomString(5, 'a')).toBe('aaaaa');
+  });
+
+  test('hash produces deterministic value', () => {
+    expect(hash('abc')).toBe(hash('abc'));
+  });
+
+  test('LCG generates values between 0 and 1', () => {
+    const lcg = new LCG(123);
+    const value = lcg.random();
+    expect(value).toBeGreaterThanOrEqual(0);
+    expect(value).toBeLessThan(1);
+  });
+
+  test('delay waits for timeout', async () => {
+    jest.useFakeTimers();
+    const spy = jest.fn();
+    const promise = delay(100).then(spy);
+    jest.advanceTimersByTime(100);
+    await promise;
+    expect(spy).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- improve tests for `formatValue`
- expand `utils` unit tests covering more helpers
- add new tests for `i18n` utilities
- document expanded coverage in README

## Testing
- `yarn test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a674383208326b2c1d45e495ded4d

## Summary by Sourcery

Expand unit test suite across utils, formatValue, and i18n modules to increase coverage to 80% and update documentation accordingly

Documentation:
- Updated README to document expanded test coverage

Tests:
- Added validation and boundary tests for utils functions
- Added formatValue tests for compact numbers, currency formatting, error cases, and date/time formatting
- Added i18n utility tests for trackingTexts, formatNumberCompact configs, and language-change task management