### PR TITLE
docs: illustrate function use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ console.log(formatCurrency(1234.56)); // Example of currency formatting
 console.log(flatten({ a: { b: { c: 1 } } })); // Converts a nested object into a flat object
 ```
 
+Minimal example of the CLI logic for CSS purging:
+
+```ts
+import purgeCss from 'dbl-utils/src/purge-css';
+purgeCss('styles.css', 'index.html', 'clean.css');
+```
+
 Imports directly from any file to don't include all:
 
 CommonJS use **/dist/cjs/\***
@@ -85,56 +92,188 @@ Below are the main modules available in `dbl-utils`:
 
 ## Utilities
 
-- **event-handler**
-  - *eventHandler*
-  - *EventHandler*
-- **fetch-queue**
-  - *FetchQueue*
-- **flat**
-  - *flatten*
-  - *unflatten*
-- **format-value**
-  - *formatValue*
-- **i18n**
-  - *trackingTexts*
-  - *getTexts*
-  - *addDictionary*
-  - *addFormatDate*
-  - *addFormatTime*
-  - *addFormatDateTime*
-  - *addFormatNumber*
-  - *addFormatNumberCompact*
-  - *addFormatCurrency*
-  - *addTasks*
-  - *removeTask*
-  - *setLang*
-  - *getLang*
-  - *formatDate*
-  - *formatTime*
-  - *formatDateTime*
-  - *formatNumber*
-  - *formatNumberCompact*
-  - *formatCurrency*
-  - *t*
-- **object-mutation**
-  - *mergeWithMutation*
-  - *deepMerge*
-  - *transformJson*
-- **resolve-refs**
-  - *resolveRefs*
-- **utils**
-  - *sliceIntoChunks*
-  - *splitAndFlat*
-  - *generateRandomColors*
-  - *evaluateColorSimilarity*
-  - *normalize*
-  - *slugify*
-  - *randomS4*
-  - *randomString*
-  - *timeChunks*
-  - *delay*
-  - *hash*
-  - *LCG*
+### event-handler
+
+Decouple communication by subscribing to and dispatching custom events.
+
+```ts
+import { EventHandler } from 'dbl-utils';
+
+const handler = new EventHandler();
+handler.subscribe('ping', msg => console.log(msg), 'id'); // listen to events
+await handler.dispatch('ping', 'pong'); // emit an event
+handler.unsubscribe('ping', 'id'); // stop listening
+```
+
+### fetch-queue
+
+Deduplicate concurrent HTTP calls so the same request is only made once.
+
+```ts
+import FetchQueue from 'dbl-utils/src/fetch-queue';
+
+const queue = new FetchQueue(fetch);
+const [a, b] = await Promise.all([
+  queue.addRequest('https://example.com'),
+  queue.addRequest('https://example.com')
+]);
+// a === b
+```
+
+### flat
+
+Convert nested objects to and from dot notation.
+
+```ts
+import { flatten, unflatten } from 'dbl-utils';
+
+flatten({ a: { b: 1 } }); // { 'a.b': 1 }
+unflatten({ 'a.b': 1 }); // { a: { b: 1 } }
+```
+
+### format-value
+
+Format numbers, dates, or dictionary entries using locale-aware helpers.
+
+```ts
+import formatValue from 'dbl-utils/src/format-value';
+
+formatValue(1000, { format: 'currency', currency: 'USD' }); // "$1,000.00"
+```
+
+### i18n
+
+Manage dictionaries and locale-aware formatting.
+
+```ts
+import t, { addDictionary, setLang, formatDate } from 'dbl-utils';
+
+addDictionary({ es: { hello: 'Hola' } });
+setLang('es');
+t('hello'); // 'Hola'
+formatDate(); // date formatted in Spanish
+```
+
+### object-mutation
+
+Combine and transform objects without modifying the originals.
+
+```ts
+import { deepMerge, mergeWithMutation, transformJson } from 'dbl-utils';
+
+deepMerge({}, { a: 1 }, { b: 2 }); // merge nested structures
+await mergeWithMutation({ a: { b: 1 } }, { mutation: () => ({ c: 2 }) }); // async mutation
+transformJson({ a: { b: 1 } }, { filter: 'a' }); // extract subset
+```
+
+### resolve-refs
+
+Replace `$path/to/value` placeholders using a schema.
+
+```ts
+import resolveRefs from 'dbl-utils';
+
+resolveRefs({ num: '$values/a' }, { values: { a: 1 } }).num; // 1
+```
+
+### utils
+
+#### sliceIntoChunks
+Split an array into smaller arrays for batching.
+
+```ts
+import { sliceIntoChunks } from 'dbl-utils';
+sliceIntoChunks([1,2,3,4],2); // [[1,2],[3,4]]
+```
+
+#### splitAndFlat
+Turn a list of strings into unique tokens.
+
+```ts
+import { splitAndFlat } from 'dbl-utils';
+splitAndFlat(['a b','c']); // ['a','b','c']
+```
+
+#### generateRandomColors
+Generate distinct colors for visualizations.
+
+```ts
+import { generateRandomColors } from 'dbl-utils';
+generateRandomColors(2); // ['#aabbcc', '#ddeeff']
+```
+
+#### evaluateColorSimilarity
+Check how close colors are to each other.
+
+```ts
+import { evaluateColorSimilarity } from 'dbl-utils';
+evaluateColorSimilarity(['#fff','#ffe']); // value near 1
+```
+
+#### normalize
+Remove accents and lowercase text.
+
+```ts
+import { normalize } from 'dbl-utils';
+normalize('á'); // 'a'
+```
+
+#### slugify
+Create URL-friendly slugs.
+
+```ts
+import { slugify } from 'dbl-utils';
+slugify('Hello World'); // 'hello-world'
+```
+
+#### randomS4
+Produce a short hex segment.
+
+```ts
+import { randomS4 } from 'dbl-utils';
+randomS4(); // '9f3b'
+```
+
+#### randomString
+Generate a random alphanumeric string.
+
+```ts
+import { randomString } from 'dbl-utils';
+randomString(5); // e.g., 'abcde'
+```
+
+#### timeChunks
+Build time intervals between two dates.
+
+```ts
+import { timeChunks } from 'dbl-utils';
+timeChunks({ from:'2020-01-01', to:'2020-01-02', step:3600 }); // [...]
+```
+
+#### delay
+Pause execution for a given time.
+
+```ts
+import { delay } from 'dbl-utils';
+await delay(10); // waits 10ms
+```
+
+#### hash
+Generate a numeric hash.
+
+```ts
+import { hash } from 'dbl-utils';
+hash('data'); // 123456789
+```
+
+#### LCG
+Deterministic pseudo-random number generator.
+
+```ts
+import { LCG } from 'dbl-utils';
+const gen = new LCG(123);
+gen.random(); // 0.5967...
+```
 
 ## Documentation
 

--- a/__tests__/event-handler.test.ts
+++ b/__tests__/event-handler.test.ts
@@ -55,5 +55,24 @@ describe('EventHandler', () => {
     expect(cacheKeyExist()).toBe(false);
   });
 
+  it('supports multiple callbacks for the same wildcard pattern', async () => {
+    const cb1 = jest.fn();
+    const cb2 = jest.fn();
+    eventHandler.subscribe('user.*', cb1, 'id1');
+    eventHandler.subscribe('user.*', cb2, 'id2');
+    await eventHandler.dispatch('user.login');
+    expect(cb1).toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalled();
+  });
+
+  it('removes pattern subscriptions from cache', async () => {
+    const cb = jest.fn();
+    eventHandler.subscribe('test*', cb, 'id');
+    await eventHandler.dispatch('testValue');
+    expect((eventHandler as any).cache.testValue).toBeDefined();
+    eventHandler.unsubscribe('test*', 'id');
+    expect((eventHandler as any).cache.testValue).toBeUndefined();
+  });
+
 });
 

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -8,7 +8,16 @@ import t, {
   addFormatNumberCompact,
   formatNumberCompact,
   addTasks,
-  removeTask
+  removeTask,
+  addFormatTime,
+  formatTime,
+  addFormatDateTime,
+  formatDateTime,
+  addFormatNumber,
+  formatNumber,
+  addFormatCurrency,
+  formatCurrency,
+  getLang
 } from '../src/i18n';
 
 describe('i18n utilities', () => {
@@ -47,5 +56,42 @@ describe('i18n utilities', () => {
     expect(spy).toHaveBeenCalledWith('fr');
     expect(removeTask('test')).toBe(true);
     expect(removeTask('test')).toBe(false);
+  });
+  test('addFormatTime and formatTime with context', () => {
+    addFormatTime({ es: { short: 'HH:mm' } });
+    setLang('es');
+    expect(formatTime('short')).toBe('HH:mm');
+  });
+
+  test('addFormatDateTime and formatDateTime with context', () => {
+    addFormatDateTime({ es: { short: 'DD/MM HH:mm' } });
+    setLang('es');
+    expect(formatDateTime('short')).toBe('DD/MM HH:mm');
+  });
+
+  test('addFormatNumber and formatNumber return objects', () => {
+    addFormatNumber({ es: { short: { maximumFractionDigits: 1 } } });
+    setLang('es');
+    expect(formatNumber('short')).toEqual({ maximumFractionDigits: 1 });
+  });
+
+  test('addFormatCurrency sets style and formatCurrency returns config', () => {
+    addFormatCurrency({ es: { short: { currency: 'EUR' } } });
+    setLang('es');
+    expect(formatCurrency('short')).toEqual({ currency: 'EUR' });
+  });
+
+  test('setLang and getLang handle invalid inputs', () => {
+    setLang('_default');
+    expect(setLang('_default')).toBe(false);
+    expect(setLang('')).toBe(false);
+    setLang('en');
+    expect(getLang()).toBe('en');
+  });
+
+  test('addDictionary rejects non objects and context lookup works', () => {
+    expect(addDictionary('nope' as any)).toBe(false);
+    addDictionary({ default: { section: { key: 'value' } } });
+    expect(t('key', 'section')).toBe('value');
   });
 });

--- a/__tests__/object-mutation.test.ts
+++ b/__tests__/object-mutation.test.ts
@@ -21,4 +21,28 @@ describe('object-mutation utilities', () => {
     expect(copy).toEqual({ a: { b: 1 } });
     expect(flat).toBeUndefined();
   });
+
+  test('deepMerge can use a fixer function', () => {
+    deepMerge.setConfig({ fix: () => ({ fixed: true }) });
+    const result = deepMerge({ a: 1 }, { b: 2 });
+    expect(result).toEqual({ fixed: true });
+  });
+
+  test('transformJson supports hooks and filter string', () => {
+    const json = { a: { b: { c: 1 } }, c: 2, d: 3 };
+    const [mod] = transformJson(json, {
+      beforeFunc: ({ key }) => (key === 'a' ? { merge: { pre: true } } : undefined),
+      duringFunc: ({ key }) => (key === 'b' ? { merge: { inner: true } } : undefined),
+      afterFunc: ({ key }) => (key === 'a' ? { merge: { post: true } } : undefined),
+      nonObjectFunc: ({ key }) => (key === 'd' ? { merge: 1 } : undefined),
+      filter: 'c'
+    });
+    expect(mod).toEqual({ a: { b: { c: 1, inner: true }, pre: true, post: true }, c: 2, d: 4 });
+  });
+
+  test('transformJson handles array and function filters', () => {
+    const json = { a: 1, b: 2, c: 3 };
+    transformJson(json, { filter: ['b'] });
+    transformJson(json, { filter: ({ key }) => key !== 'c' });
+  });
 });

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -7,6 +7,13 @@ interface Pattern {
 
 /**
  * Class EventHandler to manage event subscriptions and dispatching.
+ *
+ * @example
+ * ```ts
+ * const handler = new EventHandler();
+ * handler.subscribe('say', msg => console.log(msg), 'id1');
+ * handler.dispatch('say', 'hello');
+ * ```
  */
 export class EventHandler {
   private events: Record<string, Array<[EventCallback, string]>>;
@@ -45,6 +52,11 @@ export class EventHandler {
    * @param event - The event name to dispatch.
    * @param data - Data to be passed to the callback function.
    * @returns A promise resolved with an array of callback responses.
+   *
+   * @example
+   * ```ts
+   * await handler.dispatch('say', 'hi');
+   * ```
    */
   async dispatch(event: string, ...data: any[]): Promise<any[]> {
     if (this.cache[event]) {
@@ -67,6 +79,11 @@ export class EventHandler {
    * @param eventString - The event name or pattern to subscribe to.
    * @param callback - The callback function to execute when the event is dispatched.
    * @param id - An identifier for the subscription, used for unsubscribing.
+   *
+   * @example
+   * ```ts
+   * handler.subscribe('user.*', cb, 'id');
+   * ```
    */
   subscribe(eventString: string, callback: EventCallback, id: string): void {
     const events = eventString.split(/[\s,]+/);
@@ -94,6 +111,11 @@ export class EventHandler {
    * Unsubscribes from an event or pattern of events.
    * @param eventString - The event name or pattern to unsubscribe from.
    * @param id - The identifier of the subscription to remove.
+   *
+   * @example
+   * ```ts
+   * handler.unsubscribe('user.*', 'id');
+   * ```
    */
   unsubscribe(eventString: string, id: string): void {
     const events = eventString.split(/[\s,]+/);

--- a/src/fetch-queue.ts
+++ b/src/fetch-queue.ts
@@ -12,6 +12,18 @@ interface RequestOptions {
 
 /**
  * A queue to manage fetch requests with unique identification.
+ *
+ * Useful to deduplicate concurrent network calls to the same URL.
+ *
+ * @example
+ * ```ts
+ * const queue = new FetchQueue(fetch);
+ * const [a, b] = await Promise.all([
+ *   queue.addRequest('https://example.com/data'),
+ *   queue.addRequest('https://example.com/data')
+ * ]);
+ * // only one HTTP request is performed
+ * ```
  */
 export default class FetchQueue {
   private queue: Record<string, RequestOptions> = {};

--- a/src/format-value.ts
+++ b/src/format-value.ts
@@ -27,10 +27,16 @@ interface FormatConfig {
 
 /**
  * Formats a value based on the provided configuration.
- * 
+ *
  * @param value - The value to format
  * @param conf - Configuration options for formatting
  * @returns The formatted value or the original value if the format is not specified
+ *
+ * @example
+ * ```ts
+ * formatValue(1000, { format: 'currency', currency: 'USD' });
+ * // => "$1,000.00" in an English locale
+ * ```
  */
 export default function formatValue(value: any, conf: FormatConfig): any {
   if (!conf?.format) return value;
@@ -38,8 +44,6 @@ export default function formatValue(value: any, conf: FormatConfig): any {
   switch (conf.format) {
     case 'number-compact':
     case 'numbercompact': {
-      // TODO: move to i18n
-      // TODO: move to i18n
       numeral.locale(getLang());
       return numeral(value).format(conf.formatConf as string || formatNumberCompact(conf.context));
     }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -47,6 +47,14 @@ let trackingTextSet = new Set<string>();
  * When enabled every translation key requested will be stored.
  *
  * @param setTracking - Whether tracking should be enabled
+ *
+ * @example
+ * ```ts
+ * trackingTexts(true);
+ * t('hello');
+ * trackingTexts(false);
+ * getTexts(); // ['hello']
+ * ```
  */
 export function trackingTexts(setTracking: boolean = true): void {
   isTrackingText = setTracking;
@@ -56,6 +64,11 @@ export function trackingTexts(setTracking: boolean = true): void {
  * Retrieve the list of tracked texts.
  *
  * @returns Array of unique translation keys requested
+ *
+ * @example
+ * ```ts
+ * getTexts();
+ * ```
  */
 export function getTexts(): string[] {
   return Array.from(trackingTextSet);
@@ -65,6 +78,11 @@ export function getTexts(): string[] {
  * Adds a dictionary to the configuration object.
  * @param {Object} dictionary - The dictionary to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addDictionary({ es: { hello: 'Hola' } });
+ * ```
  */
 export const addDictionary = (dictionary: object): boolean => {
   if (typeof dictionary !== 'object') return false;
@@ -76,6 +94,11 @@ export const addDictionary = (dictionary: object): boolean => {
  * Adds date formats to the configuration object.
  * @param {Object} formats - The date formats to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addFormatDate({ es: 'DD/MM/YYYY' });
+ * ```
  */
 export const addFormatDate = (formats: object): boolean => {
   if (typeof formats !== 'object') return false;
@@ -87,6 +110,11 @@ export const addFormatDate = (formats: object): boolean => {
  * Adds time formats to the configuration object.
  * @param {Object} formats - The time formats to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addFormatTime({ es: 'HH:mm' });
+ * ```
  */
 export const addFormatTime = (formats: object): boolean => {
   if (typeof formats !== 'object') return false;
@@ -98,6 +126,11 @@ export const addFormatTime = (formats: object): boolean => {
  * Adds date-time formats to the configuration object.
  * @param {Object} formats - The date-time formats to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addFormatDateTime({ es: 'DD/MM HH:mm' });
+ * ```
  */
 export const addFormatDateTime = (formats: object): boolean => {
   if (typeof formats !== 'object') return false;
@@ -109,6 +142,11 @@ export const addFormatDateTime = (formats: object): boolean => {
  * Adds number formats to the configuration object.
  * @param {Object} formats - The number formats to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addFormatNumber({ es: { short: { maximumFractionDigits: 1 } } });
+ * ```
  */
 export const addFormatNumber = (formats: object): boolean => {
   if (typeof formats !== 'object') return false;
@@ -120,6 +158,11 @@ export const addFormatNumber = (formats: object): boolean => {
  * Adds compact number formats to the configuration object.
  * @param {Object} formats - The compact number formats to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addFormatNumberCompact({ es: '0a' });
+ * ```
  */
 export const addFormatNumberCompact = (formats: object): boolean => {
   if (typeof formats !== 'object') return false;
@@ -131,6 +174,11 @@ export const addFormatNumberCompact = (formats: object): boolean => {
  * Adds currency formats to the configuration object.
  * @param {Object} formats - The currency formats to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addFormatCurrency({ es: { short: { currency: 'EUR' } } });
+ * ```
  */
 export const addFormatCurrency = (formats: object): boolean => {
   if (typeof formats !== 'object') return false;
@@ -143,6 +191,11 @@ export const addFormatCurrency = (formats: object): boolean => {
  * Adds tasks to be executed on language change.
  * @param {Object} tasks - The tasks to add.
  * @returns {boolean} True if added correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * addTasks({ reload: lang => console.log(lang) });
+ * ```
  */
 export const addTasks = (tasks: Record<string, (lang: string) => void>): boolean => {
   Object.entries(tasks).forEach(([key, task]) => {
@@ -155,6 +208,11 @@ export const addTasks = (tasks: Record<string, (lang: string) => void>): boolean
  * Removes a specific task.
  * @param {string} key - The key of the task to remove.
  * @returns {boolean} True if removed, false otherwise.
+ *
+ * @example
+ * ```ts
+ * removeTask('reload');
+ * ```
  */
 export const removeTask = (key: string): boolean => {
   if (!config.tasks[key]) return false;
@@ -166,6 +224,11 @@ export const removeTask = (key: string): boolean => {
  * Sets the current language.
  * @param {string} newLang - The new language to set.
  * @returns {boolean} True if set correctly, false otherwise.
+ *
+ * @example
+ * ```ts
+ * setLang('es');
+ * ```
  */
 export const setLang = (newLang: string): boolean => {
   if (!newLang || config.lang === newLang) return false;
@@ -178,6 +241,11 @@ export const setLang = (newLang: string): boolean => {
 /**
  * Gets the current language.
  * @returns {string} The current language.
+ *
+ * @example
+ * ```ts
+ * const lang = getLang();
+ * ```
  */
 export const getLang = (): string => {
   return config.lang;
@@ -201,6 +269,13 @@ const selectFromDefault = (text: string, context?: string): string => {
  * @param {string} text - The text to translate.
  * @param {string} [context] - The context of the text.
  * @returns {string} The translated text.
+ *
+ * @example
+ * ```ts
+ * addDictionary({ es: { hello: 'Hola' } });
+ * setLang('es');
+ * t('hello'); // 'Hola'
+ * ```
  */
 const t = (text: string, context?: string): string => {
   if (isTrackingText) {
@@ -238,6 +313,11 @@ function formatGeneric(formatObject: Record<string, any>, context?: string): str
  * Formats a date according to the current language and context.
  * @param {string} [context] - The context of the date.
  * @returns {string} The formatted date.
+ *
+ * @example
+ * ```ts
+ * formatDate();
+ * ```
  */
 export const formatDate = (context?: string): string => {
   return formatGeneric(config.formatDate, context);
@@ -247,6 +327,11 @@ export const formatDate = (context?: string): string => {
  * Formats a time according to the current language and context.
  * @param {string} [context] - The context of the time.
  * @returns {string} The formatted time.
+ *
+ * @example
+ * ```ts
+ * formatTime();
+ * ```
  */
 export const formatTime = (context?: string): string => {
   return formatGeneric(config.formatTime, context);
@@ -256,6 +341,11 @@ export const formatTime = (context?: string): string => {
  * Formats a date-time according to the current language and context.
  * @param {string} [context] - The context of the date-time.
  * @returns {string} The formatted date-time.
+ *
+ * @example
+ * ```ts
+ * formatDateTime();
+ * ```
  */
 export const formatDateTime = (context?: string): string => {
   return formatGeneric(config.formatDateTime, context);
@@ -265,6 +355,11 @@ export const formatDateTime = (context?: string): string => {
  * Formats a number according to the current language and context.
  * @param {string} [context] - The context of the number.
  * @returns {string} The formatted number.
+ *
+ * @example
+ * ```ts
+ * formatNumber();
+ * ```
  */
 export const formatNumber = (context?: string): string => {
   return formatGeneric(config.formatNumber, context);
@@ -274,6 +369,11 @@ export const formatNumber = (context?: string): string => {
  * Formats a compact number according to the current language and context.
  * @param {string} [context] - The context of the compact number.
  * @returns {string} The formatted compact number.
+ *
+ * @example
+ * ```ts
+ * formatNumberCompact();
+ * ```
  */
 export const formatNumberCompact = (context?: string): string => {
   return formatGeneric(config.formatNumberCompact, context);
@@ -283,6 +383,11 @@ export const formatNumberCompact = (context?: string): string => {
  * Formats a currency according to the current language and context.
  * @param {string} [context] - The context of the currency.
  * @returns {string} The formatted currency.
+ *
+ * @example
+ * ```ts
+ * formatCurrency();
+ * ```
  */
 export const formatCurrency = (context?: string): string => {
   return formatGeneric(config.formatCurrency, context);

--- a/src/object-mutation.ts
+++ b/src/object-mutation.ts
@@ -74,6 +74,12 @@ function effectiveDeepMerge(target: any, ...sources: any[]): any {
  * @param options - Options for mutation, ommit keys and additional data.
  * @param parentKey - Internal tracking key for recursion.
  * @returns The mutated and merged target object.
+ *
+ * @example
+ * ```ts
+ * await mergeWithMutation({ a: { b: 1 } }, { mutation: () => ({ c: 2 }) });
+ * // => { a: { b: 1, c: 2 } }
+ * ```
  */
 export async function mergeWithMutation(
   target: any,
@@ -96,6 +102,11 @@ export async function mergeWithMutation(
  * @param target - The target object where other objects will be merged.
  * @param sources - Other objects to be merged into the target.
  * @returns The merged object.
+ *
+ * @example
+ * ```ts
+ * deepMerge({}, { a: 1 }, { b: 2 }); // { a: 1, b: 2 }
+ * ```
  */
 export function deepMerge(target: any, ...sources: any[]): any {
   const mergedObject = effectiveDeepMerge(target, ...sources);
@@ -108,6 +119,12 @@ export function deepMerge(target: any, ...sources: any[]): any {
  * fixer function before calling {@link deepMerge}.
  *
  * @param config - Configuration options.
+ *
+ * @example
+ * ```ts
+ * deepMerge.setConfig({ fix: () => ({ fixed: true }) });
+ * deepMerge({}, { a: 1 }); // { fixed: true }
+ * ```
  */
 deepMerge.setConfig = (config: ConfigOptions) => {
   useConfig = config;
@@ -119,6 +136,12 @@ deepMerge.setConfig = (config: ConfigOptions) => {
  * @param json - The JSON object to be transformed.
  * @param options - Options for the mutation functions.
  * @returns An array with the modified object and the flattened object.
+ *
+ * @example
+ * ```ts
+ * transformJson({ a: { b: 1 } }, { filter: 'a' });
+ * // => [{ a: { b: 1 } }, { a: { b: 1 } }]
+ * ```
  */
 export function transformJson(json: any, options: TransformOptions = {}): [any, any] {
   const objCopy = JSON.parse(JSON.stringify(json));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,12 @@ export type IArrayString = (null | undefined | boolean | string | IArrayString)[
  * @param {string[]} arrayStrings - Array of strings to split and flatten.
  * @param {string} separator - Separator to use for splitting.
  * @returns {string[]} Flattened and splitted array of strings.
+ *
+ * @example
+ * ```ts
+ * splitAndFlat(['tag1 tag2', 'tag2'], ' ');
+ * // => ['tag1', 'tag2']
+ * ```
  */
 export function splitAndFlat(
   arrayStrings: IArrayString,
@@ -121,6 +127,12 @@ function transform(value: number, limit: number | number[]): number {
  * Evaluates the similarity of a set of colors.
  * @param cls - Array of colors in hex format.
  * @returns A similarity score between 0 and 1, where 0 indicates all colors are distinct and 1 indicates all are similar.
+ *
+ * @example
+ * ```ts
+ * evaluateColorSimilarity(['#ffffff', '#fffffe']);
+ * // => value close to 1
+ * ```
  */
 export function evaluateColorSimilarity(colors: string[]): number {
   let totalDistance = 0;
@@ -145,6 +157,12 @@ export function evaluateColorSimilarity(colors: string[]): number {
  * Normalizes a string by converting it to lowercase and removing diacritical marks.
  * @param {string} str - The string to normalize.
  * @returns {string} The normalized string.
+ *
+ * @example
+ * ```ts
+ * normalize('Árbol');
+ * // => 'arbol'
+ * ```
  */
 export function normalize(str: string = ''): string {
   return str.toLowerCase()
@@ -156,6 +174,12 @@ export function normalize(str: string = ''): string {
  * Converts a string to a slug.
  * @param {string} str - The string to slugify.
  * @returns {string} The slugified string.
+ *
+ * @example
+ * ```ts
+ * slugify('Hello World!');
+ * // => 'hello-world'
+ * ```
  */
 export function slugify(str: string = ''): string {
   return normalize(str)
@@ -167,6 +191,12 @@ export function slugify(str: string = ''): string {
 /**
  * Generates a random four-character string consisting of hexadecimal digits.
  * @returns {string} The random four-character string.
+ *
+ * @example
+ * ```ts
+ * randomS4();
+ * // => '9f3b'
+ * ```
  */
 export function randomS4(): string {
   return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
@@ -178,6 +208,12 @@ export function randomS4(): string {
  * @param {number} [length=16] - The length of the generated string. Default is 16.
  * @param {string} [characters='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'] - A string representing the characters to be used. Default includes uppercase, lowercase letters, and digits.
  * @returns {string} A random string composed of the specified characters.
+ *
+ * @example
+ * ```ts
+ * randomString(5);
+ * // => e.g., 'aB3dE'
+ * ```
  */
 export function randomString(
   length: number = 16,
@@ -261,6 +297,12 @@ export function timeChunks(options: { from: string | number, to: string | number
  * Resolves the promise after a given timeout.
  * @param {number} timeout - Milliseconds to wait before resolving.
  * @returns {Promise<void>} The promise that resolves after the timeout.
+ *
+ * @example
+ * ```ts
+ * await delay(1000);
+ * // waits for one second
+ * ```
  */
 export function delay(timeout: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, timeout));
@@ -272,6 +314,12 @@ export function delay(timeout: number): Promise<void> {
  * Computes the hash value of a string.
  * @param {string} string - The string to hash.
  * @returns {number} The computed hash value.
+ *
+ * @example
+ * ```ts
+ * hash('abc');
+ * // => deterministic numeric hash
+ * ```
  */
 export function hash(string: string): number {
   let hash = 0, i, chr;
@@ -286,6 +334,13 @@ export function hash(string: string): number {
 /**
  * Linear Congruential Generator (LCG) class for pseudo-random number generation.
  * @class LCG
+ *
+ * @example
+ * ```ts
+ * const gen = new LCG(123);
+ * gen.random();
+ * // => 0.596735... (deterministic)
+ * ```
  */
 export class LCG {
   private a: number;


### PR DESCRIPTION
## Summary
- add TypeDoc examples for fetch-queue and utility helpers
- expand README with per-function use-case examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af6951805883269e1340207a2a13db

## Summary by Sourcery

Illustrate function use cases by adding practical examples in code documentation and README, and strengthen coverage with tests for the new usage scenarios

Enhancements:
- Add @example code snippets to TypeDoc comments across i18n, utilities, event-handler, object-mutation, fetch-queue, and format-value modules

Documentation:
- Expand README with per-function usage examples for all utility modules and a minimal CLI purge-CSS snippet

Tests:
- Add unit tests for i18n formatting helpers, event-handler wildcard subscription behaviors, deepMerge config fixer, transformJson hooks, and fetch-queue deduplication